### PR TITLE
fix: CI build order + feat: shape properties support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
-      - name: Test
-        run: npm test
-
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test

--- a/schemas/shape.schema.json
+++ b/schemas/shape.schema.json
@@ -85,6 +85,50 @@
         }
       }
     },
+    "properties": {
+      "type": "array",
+      "description": "Custom properties that provide context to the shape (key-value metadata shown in draw.io's Edit Data dialog)",
+      "items": {
+        "type": "object",
+        "required": ["key", "label"],
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$",
+            "description": "Property key (used as XML attribute name)"
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label shown in draw.io Edit Data"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["string", "enum", "boolean", "number"],
+            "default": "string",
+            "description": "Property value type"
+          },
+          "default": {
+            "type": "string",
+            "description": "Default value for the property"
+          },
+          "options": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Allowed values (for enum type)"
+          },
+          "required": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this property must be filled in"
+          },
+          "description": {
+            "type": "string",
+            "description": "Help text explaining what this property is for"
+          }
+        }
+      }
+    },
     "deprecated": {
       "type": "boolean",
       "default": false,

--- a/shapes/application/application-component.yaml
+++ b/shapes/application/application-component.yaml
@@ -14,3 +14,29 @@ visual:
 dimensions:
   width: 120
   height: 60
+properties:
+  - key: owner
+    label: Owner
+    type: string
+    default: ""
+    description: Team or person responsible for this component
+  - key: status
+    label: Status
+    type: enum
+    default: active
+    options:
+      - active
+      - deprecated
+      - planned
+      - retiring
+    description: Current lifecycle status
+  - key: criticality
+    label: Criticality
+    type: enum
+    default: medium
+    options:
+      - low
+      - medium
+      - high
+      - critical
+    description: Business criticality level

--- a/shapes/business/business-process.yaml
+++ b/shapes/business/business-process.yaml
@@ -14,3 +14,25 @@ visual:
 dimensions:
   width: 120
   height: 60
+properties:
+  - key: processOwner
+    label: Process Owner
+    type: string
+    default: ""
+  - key: automationLevel
+    label: Automation Level
+    type: enum
+    default: manual
+    options:
+      - manual
+      - semi-automated
+      - fully-automated
+  - key: maturity
+    label: Maturity
+    type: enum
+    default: defined
+    options:
+      - initial
+      - defined
+      - managed
+      - optimized

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -78,7 +78,10 @@ export async function extractCommand(
         continue;
       }
 
-      const yamlDoc = {
+      // Extract custom properties from cell attributes
+      const properties = extractProperties(cell.attributes, styleMap);
+
+      const yamlDoc: Record<string, unknown> = {
         blockId,
         name: inferName(blockId),
         layer,
@@ -95,6 +98,10 @@ export async function extractCommand(
           height: cell.geometry?.height || 60,
         },
       };
+
+      if (properties.length > 0) {
+        yamlDoc.properties = properties;
+      }
 
       mkdirSync(layerDir, { recursive: true });
       writeFileSync(yamlPath, stringify(yamlDoc));
@@ -196,4 +203,42 @@ function inferName(blockId: string): string {
     .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
+}
+
+// Attributes to skip — these are internal draw.io or managed by our tool
+const SKIP_ATTRIBUTES = new Set([
+  "data-block-id",
+  "data-library-version",
+  "placeholders",
+]);
+
+function extractProperties(
+  attributes: Record<string, string>,
+  styleMap: Map<string, string>,
+): Array<{ key: string; label: string; type: string; default: string }> {
+  const properties: Array<{ key: string; label: string; type: string; default: string }> = [];
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (SKIP_ATTRIBUTES.has(key)) continue;
+    // Skip style-related attributes that are already captured
+    if (styleMap.has(key)) continue;
+
+    properties.push({
+      key,
+      label: key
+        .replace(/([A-Z])/g, " $1")
+        .replace(/^./, (s) => s.toUpperCase())
+        .trim(),
+      type: inferPropertyType(value),
+      default: value,
+    });
+  }
+
+  return properties;
+}
+
+function inferPropertyType(value: string): string {
+  if (value === "true" || value === "false") return "boolean";
+  if (!isNaN(Number(value)) && value.length > 0) return "number";
+  return "string";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,5 @@ export const LIBRARY_PATH = join(__dirname, "..", "libraries");
 export const VERSION = "0.1.0";
 
 export { SHAPES, SHAPES_BY_ID, LAYER_COLORS } from "./library/shapes.js";
-export type { ShapeDefinition, ArchiMateLayer } from "./library/shapes.js";
+export type { ShapeDefinition, ShapeProperty, ArchiMateLayer } from "./library/shapes.js";
 export { generateLibraryXml, generateLibraryForLayer } from "./library/generator.js";

--- a/src/library/generator.ts
+++ b/src/library/generator.ts
@@ -8,17 +8,40 @@ function shapeToLibraryEntry(shape: ShapeDefinition, version: string): string {
     `data-library-version=${version}`,
   ].join(";");
 
-  const xml = [
-    `<mxGraphModel>`,
-    `  <root>`,
-    `    <mxCell id="0"/>`,
-    `    <mxCell id="1" parent="0"/>`,
-    `    <mxCell id="2" value="${escapeXml(shape.name)}" style="${escapeXml(styleWithMeta)}" vertex="1" parent="1">`,
-    `      <mxGeometry width="${shape.width}" height="${shape.height}" as="geometry"/>`,
-    `    </mxCell>`,
-    `  </root>`,
-    `</mxGraphModel>`,
-  ].join("");
+  let xml: string;
+
+  if (shape.properties && shape.properties.length > 0) {
+    // Use <object> wrapper for shapes with custom properties
+    const propAttrs = shape.properties
+      .map((p) => `${escapeXml(p.key)}="${escapeXml(p.default || "")}"`)
+      .join(" ");
+
+    xml = [
+      `<mxGraphModel>`,
+      `  <root>`,
+      `    <mxCell id="0"/>`,
+      `    <mxCell id="1" parent="0"/>`,
+      `    <object id="2" label="${escapeXml(shape.name)}" ${propAttrs}>`,
+      `      <mxCell style="${escapeXml(styleWithMeta)}" vertex="1" parent="1">`,
+      `        <mxGeometry width="${shape.width}" height="${shape.height}" as="geometry"/>`,
+      `      </mxCell>`,
+      `    </object>`,
+      `  </root>`,
+      `</mxGraphModel>`,
+    ].join("");
+  } else {
+    xml = [
+      `<mxGraphModel>`,
+      `  <root>`,
+      `    <mxCell id="0"/>`,
+      `    <mxCell id="1" parent="0"/>`,
+      `    <mxCell id="2" value="${escapeXml(shape.name)}" style="${escapeXml(styleWithMeta)}" vertex="1" parent="1">`,
+      `      <mxGeometry width="${shape.width}" height="${shape.height}" as="geometry"/>`,
+      `    </mxCell>`,
+      `  </root>`,
+      `</mxGraphModel>`,
+    ].join("");
+  }
 
   return JSON.stringify({
     xml,

--- a/src/library/shapes.ts
+++ b/src/library/shapes.ts
@@ -19,6 +19,16 @@ function findShapesDir(): string {
 
 const SHAPES_DIR = findShapesDir();
 
+export interface ShapeProperty {
+  key: string;
+  label: string;
+  type?: "string" | "enum" | "boolean" | "number";
+  default?: string;
+  options?: string[];
+  required?: boolean;
+  description?: string;
+}
+
 export interface ShapeDefinition {
   blockId: string;
   name: string;
@@ -28,6 +38,7 @@ export interface ShapeDefinition {
   strokeColor: string;
   width: number;
   height: number;
+  properties?: ShapeProperty[];
   deprecated?: boolean;
   deprecatedSince?: string;
   replacedBy?: string;
@@ -74,6 +85,7 @@ interface YamlShape {
     width: number;
     height: number;
   };
+  properties?: ShapeProperty[];
   deprecated?: boolean;
   deprecatedSince?: string;
   replacedBy?: string;
@@ -129,6 +141,7 @@ function loadShapesFromDir(dir: string): ShapeDefinition[] {
         strokeColor: yaml.visual.strokeColor,
         width: yaml.dimensions.width,
         height: yaml.dimensions.height,
+        properties: yaml.properties,
         deprecated: yaml.deprecated,
         deprecatedSince: yaml.deprecatedSince,
         replacedBy: yaml.replacedBy,


### PR DESCRIPTION
## Summary
- **CI fix**: moved build step before test — cli.test.ts requires dist/cli.js
- **Properties support**: shapes can define custom key-value properties (owner, status, criticality, etc.) that appear in draw.io's Edit Data dialog
  - YAML schema updated with `properties` array
  - Generator wraps shapes with properties in `<object>` elements
  - Extract command captures custom attributes from .drawio files
  - Example properties on application-component and business-process

## Test plan
- [x] `npm test` — 415 tests passing
- [x] `npm run validate` — all 60 YAML files valid with new schema
- [x] Generated XML verified: application-component has owner, status, criticality attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)