### PR TITLE
docs: update all documentation + GitHub Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/pages/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: docs/pages
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## What This Is
 
-An npm package (`@ea-toolkit/architecture-blocks`) that distributes a custom draw.io shape library for architecture diagrams (ArchiMate context blocks) and includes a CLI tool to upgrade existing diagrams when the library changes.
+An npm package (`@ea-toolkit/architecture-blocks`) that distributes a versioned draw.io shape library for ArchiMate architecture blocks. Includes a CLI to extract shape definitions from draw.io, upgrade existing diagrams when the library changes, and check for stale shapes in CI.
 
-Think: versioned shape library with a `npx architecture-blocks upgrade` command that updates styles across all your .drawio files.
+Think: versioned, YAML-driven shape library with `npx architecture-blocks upgrade` to keep all your .drawio files in sync, and `npx architecture-blocks extract` to capture new shapes directly from draw.io.
 
 ## Architecture
 
@@ -12,53 +12,110 @@ Think: versioned shape library with a `npx architecture-blocks upgrade` command 
 architecture-blocks/
 ├── CLAUDE.md
 ├── REQUIREMENTS.md
-├── package.json              # npm package config
+├── README.md
+├── SECURITY.md
+├── LICENSE
+├── package.json
 ├── tsconfig.json
 ├── vitest.config.ts
+├── tsup.config.ts
+├── schemas/
+│   └── shape.schema.json         # JSON Schema for YAML shape files
+├── shapes/                        # YAML shape definitions (source of truth)
+│   ├── application/               # One YAML file per shape, organized by layer
+│   │   ├── application-component.yaml
+│   │   ├── application-service.yaml
+│   │   └── ...
+│   ├── business/
+│   ├── technology/
+│   ├── strategy/
+│   ├── motivation/
+│   ├── implementation/
+│   ├── physical/
+│   └── composite/
 ├── src/
-│   ├── index.ts              # Package exports (library path, version)
-│   ├── cli.ts                # CLI entry point (upgrade, check, version)
+│   ├── index.ts                   # Package exports (shapes, generator, version)
+│   ├── cli.ts                     # CLI entry point (7 commands)
+│   ├── commands/
+│   │   ├── upgrade.ts             # Upgrade shape styles in .drawio files
+│   │   ├── check.ts               # Report stale shapes (CI-ready, exit code 1)
+│   │   ├── extract.ts             # Extract shapes from .drawio → YAML
+│   │   ├── version.ts             # Show version and shape count
+│   │   ├── rollback.ts            # Restore .drawio from .bak backup
+│   │   ├── diff-versions.ts       # Show changes between library versions
+│   │   └── format.ts              # Terminal output formatting
 │   ├── lib/
-│   │   ├── parser.ts         # Draw.io XML parser (extract cells, shapes, edges)
-│   │   ├── matcher.ts        # Match diagram shapes to library definitions via data-block-id
-│   │   ├── differ.ts         # Diff shape styles (current vs library)
-│   │   ├── upgrader.ts       # Apply style updates to diagram XML
-│   │   ├── backup.ts         # File backup/restore (.drawio.bak)
-│   │   └── validator.ts      # XML validation (before/after modification)
+│   │   ├── parser.ts              # Draw.io XML parser (multi-page, compressed)
+│   │   ├── matcher.ts             # Match shapes by data-block-id
+│   │   ├── differ.ts              # Diff visual styles (current vs library)
+│   │   ├── upgrader.ts            # Apply style updates (preserves layout)
+│   │   ├── backup.ts              # .drawio.bak create/restore
+│   │   ├── validator.ts           # XML validation before/after modification
+│   │   ├── scanner.ts             # Recursive .drawio finder + monorepo support
+│   │   └── config.ts              # Consumer config (.architecture-blocksrc.json)
 │   └── library/
-│       ├── shapes.ts         # Shape definitions (block-id, style, colors, dimensions)
-│       ├── generator.ts      # Generate library XML from shape definitions
-│       └── versions.ts       # Version tracking and migration map
-├── dist/                     # Built output
-├── libraries/                # Generated .xml library files
+│       ├── shapes.ts              # YAML loader → ShapeDefinition[]
+│       ├── generator.ts           # Generate library XML from shapes
+│       └── versions.ts            # Version history and migration map
+├── dist/                          # Built output (CLI + library)
+├── libraries/                     # Generated .xml library files
+├── plugin/                        # draw.io plugin for auto-import
+├── scripts/
+│   ├── generate-library.ts        # Build step: YAML → library XML
+│   └── validate-shapes.ts         # Build step: validate YAML against schema
 ├── test/
-│   ├── fixtures/             # Sample .drawio files for testing
+│   ├── fixtures/                  # Sample .drawio files
 │   ├── parser.test.ts
 │   ├── matcher.test.ts
 │   ├── differ.test.ts
 │   ├── upgrader.test.ts
-│   └── cli.test.ts
-└── scripts/
-    └── postinstall.ts        # Copy library to configurable location
+│   ├── cli.test.ts
+│   ├── roundtrip.test.ts          # 361 tests: generate → parse → verify
+│   └── coverage.test.ts           # ArchiMate 3.2 completeness (60/60)
+├── docs/
+│   ├── enterprise-guide.md
+│   ├── archimate-coverage.md
+│   ├── VERSIONING.md
+│   └── BREAKING_CHANGES.md
+└── .github/
+    ├── workflows/
+    │   ├── ci.yml                 # Test/lint/build on PR (Node 18+20)
+    │   ├── publish.yml            # npm publish with provenance on release
+    │   └── publish-gpr.yml        # GitHub Packages publish on release
+    ├── dependabot.yml
+    ├── CODEOWNERS
+    ├── pull_request_template.md
+    └── ISSUE_TEMPLATE/
+        ├── shape-request.yml
+        ├── bug-report.yml
+        └── style-change.yml
 ```
 
 ## Tech Stack
 
 - **Language:** TypeScript (strict mode)
 - **Build:** tsup (bundles CLI + library)
-- **Testing:** vitest
+- **Testing:** vitest (415 tests)
 - **Package manager:** npm
-- **XML parsing:** fast-xml-parser (lightweight, no native dependencies)
+- **XML parsing:** fast-xml-parser
+- **YAML:** yaml (shape definitions)
 - **CLI:** commander.js
+- **CI/CD:** GitHub Actions
 - **No runtime dependencies on draw.io** — operates purely on XML files
 
 ## Key Concepts
 
 ### Shape Identity
-Every shape has a `data-block-id` attribute (e.g., "bounded-context", "aggregate", "domain-event") and a `data-library-version` attribute. These are the join keys that make upgrades possible — they survive drag-and-drop onto a canvas and persist in the diagram XML.
+Every shape has a `data-block-id` attribute (e.g., "application-component") and a `data-library-version` attribute embedded in the draw.io style string. These survive drag-and-drop onto a canvas and persist in the diagram XML — they're the join keys that make upgrades possible.
+
+### YAML as Source of Truth
+Shapes are defined in individual YAML files under `shapes/<layer>/`. Each YAML file specifies the archimate stencil, visual properties, dimensions, and optional custom properties. The build reads YAML and generates draw.io library XML.
+
+### Shape Properties (Context)
+Shapes can define custom properties (key-value metadata) that appear in draw.io's Edit Data dialog. Properties like `owner`, `status`, `criticality` give shapes context beyond visual appearance. Properties are embedded as `<object>` attributes in the generated XML.
 
 ### Upgrade Logic
-The CLI finds all .drawio files, parses the XML, matches shapes by `data-block-id`, compares current style against library definition, and updates only visual properties (colors, stroke, font). Never touches positions, connections, labels, or grouping.
+The CLI finds .drawio files, parses XML, matches shapes by `data-block-id`, compares current style against the YAML definition, and updates only visual properties (colors, stroke, font). Never touches positions, connections, labels, or grouping.
 
 ### Safety
 - Backups created before writing (.drawio.bak)
@@ -66,26 +123,33 @@ The CLI finds all .drawio files, parses the XML, matches shapes by `data-block-i
 - Malformed output → abort and restore backup
 - Exit codes: 0 = success, 1 = stale shapes found, 2 = error
 
+## CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `upgrade [path]` | Update shape styles to match current library |
+| `check [path]` | Report stale shapes without modifying (CI-ready) |
+| `extract <file>` | Extract shapes from .drawio to YAML definitions |
+| `version` | Show installed version and shape count |
+| `versions` | List all library version history |
+| `diff-versions <from> <to>` | Show changes between two versions |
+| `rollback <file>` | Restore .drawio from .bak backup |
+
 ## ArchiMate Layer Colors
 
-From architecture-catalog convention:
-- Application: #99ffff
-- Business: #ffff99
-- Technology: #99ff99
-- Strategy: #F5DEAA
-- Motivation: #CCCCFF
-- Implementation: #FFE0E0
-- Physical: #99ff99
-- Composite: #E0E0E0
+| Layer | Fill | Stroke |
+|-------|------|--------|
+| Application | #99ffff | #00cccc |
+| Business | #ffff99 | #cccc00 |
+| Technology | #99ff99 | #00cc00 |
+| Strategy | #F5DEAA | #c4a050 |
+| Motivation | #CCCCFF | #9999cc |
+| Implementation | #FFE0E0 | #cc9999 |
+| Physical | #99ff99 | #00cc00 |
+| Composite | #E0E0E0 | #999999 |
 
 ## Git Strategy
 
 - Small, focused commits with conventional prefixes
 - Never commit to main — feature branches with PRs
 - Personal git config: rajnavakoti / rajnavakoti@gmail.com
-
-## Reference
-
-- Existing Python scripts in media-manager/demo/ for XML generation patterns
-- Draw.io XML format: shapes use mxGraphModel > root > mxCell with style attributes
-- ArchiMate 3 stencils: `shape=mxgraph.archimate3.*` with layer-specific type attributes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Architecture Blocks
 
-Versioned draw.io shape library for ArchiMate architecture blocks with a CLI to keep diagrams in sync.
+Versioned draw.io shape library for ArchiMate architecture blocks — with a CLI to extract, upgrade, check, and manage shapes across your diagrams.
+
+**60 shapes** covering all 8 ArchiMate 3.2 layers. **YAML-driven** definitions with custom properties. **CI-ready** with exit codes for pipeline integration.
+
+[Full Documentation](https://ea-toolkit.github.io/architecture-blocks/) | [ArchiMate Coverage](docs/archimate-coverage.md) | [Enterprise Guide](docs/enterprise-guide.md)
 
 ## Install
 
@@ -8,121 +12,151 @@ Versioned draw.io shape library for ArchiMate architecture blocks with a CLI to 
 npm install @ea-toolkit/architecture-blocks
 ```
 
-## Usage
+## Quick Start
 
-### Import the library into draw.io
+### 1. Import the library into draw.io
 
-1. Open draw.io
-2. File > Open Library from > Device
-3. Select `node_modules/@ea-toolkit/architecture-blocks/libraries/architecture-blocks.xml`
+Open draw.io, then File > Open Library from > Device and select:
+```
+node_modules/@ea-toolkit/architecture-blocks/libraries/architecture-blocks.xml
+```
 
-Per-layer libraries are also available (e.g., `architecture-blocks-application.xml`, `architecture-blocks-business.xml`).
+Per-layer libraries are also available (e.g., `architecture-blocks-application.xml`).
 
-### Check for stale shapes
+### 2. Use shapes in your diagrams
+
+Drag shapes from the library onto your canvas. Each shape comes with:
+- `data-block-id` — unique identifier for upgrade matching
+- `data-library-version` — tracks which library version created it
+- Custom properties (owner, status, criticality, etc.) — accessible via Edit > Edit Data
+
+### 3. Check for stale shapes
 
 ```bash
 npx architecture-blocks check [path]
-```
-
-Reports shapes whose styles don't match the current library version. Exits with code 1 if stale shapes are found — useful for CI.
-
-```bash
-npx architecture-blocks check ./diagrams --verbose
 # 5 blocks found, 1 stale across 1 of 3 files
+# Exit code 1 if stale (for CI)
 ```
 
-### Upgrade shapes
+### 4. Upgrade shapes
 
 ```bash
 npx architecture-blocks upgrade [path]
+# Updates visual styles only. Never touches positions, connections, or labels.
 ```
 
-Updates visual styles (colors, stroke, font) to match the current library. Positions, connections, labels, and grouping are never modified.
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `upgrade [path]` | Update shape styles to match current library |
+| `check [path]` | Report stale shapes without modifying (exit 1 = stale) |
+| `extract <file>` | Extract shapes from a .drawio file to YAML definitions |
+| `version` | Show installed library version and shape count |
+| `versions` | List all library version history |
+| `diff-versions <from> <to>` | Show changes between two versions |
+| `rollback <file>` | Restore a .drawio file from its .bak backup |
+
+### Upgrade options
 
 ```bash
-# Preview changes without modifying files
-npx architecture-blocks upgrade ./diagrams --dry-run
-
-# Upgrade without creating .bak files
-npx architecture-blocks upgrade ./diagrams --no-backup
-
-# Show per-shape details
-npx architecture-blocks upgrade ./diagrams --verbose
+npx architecture-blocks upgrade ./diagrams --dry-run    # Preview without modifying
+npx architecture-blocks upgrade ./diagrams --no-backup  # Skip .bak creation
+npx architecture-blocks upgrade ./diagrams --verbose    # Per-shape detail
 ```
 
-A `.drawio.bak` backup is created before each file is modified. If the output XML is malformed, the backup is restored automatically.
+### Extract shapes from draw.io
 
-### Show version info
+No need to hand-write YAML. Drop shapes on a draw.io canvas and extract:
 
 ```bash
-npx architecture-blocks version
-# architecture-blocks v0.1.0
-#   Shapes: 60
-#   Library: /path/to/libraries
+npx architecture-blocks extract reference.drawio --output shapes/
+#   extracted application-component -> application/application-component.yaml
+#   extracted business-actor -> business/business-actor.yaml
+#   ...
+# 20 shapes extracted, 0 skipped.
 ```
 
-## How it works
+Bulk extraction: drop as many shapes as you want on one canvas, extract all at once.
 
-Every shape in the library has a `data-block-id` attribute (e.g., `application-component`, `business-actor`) and a `data-library-version` attribute. These persist when shapes are dragged onto a canvas and saved in the diagram XML.
+## How It Works
 
-The CLI parses `.drawio` files, matches shapes by `data-block-id`, compares their current styles against the library definition, and updates only visual properties.
-
-## ArchiMate layers
-
-| Layer | Fill | Shapes |
-|-------|------|--------|
-| Application | `#99ffff` | Component, Interface, Function, Process, Event, Service, Collaboration, Data Object |
-| Business | `#ffff99` | Actor, Role, Collaboration, Interface, Process, Function, Event, Service, Object, Contract, Representation, Product |
-| Technology | `#99ff99` | Node, Device, System Software, Interface, Process, Function, Event, Service, Collaboration, Artifact, Communication Network, Path |
-| Strategy | `#F5DEAA` | Resource, Capability, Value Stream, Course of Action |
-| Motivation | `#CCCCFF` | Stakeholder, Driver, Assessment, Goal, Outcome, Principle, Requirement, Constraint, Meaning, Value |
-| Implementation | `#FFE0E0` | Work Package, Deliverable, Event, Plateau, Gap |
-| Physical | `#99ff99` | Equipment, Facility, Distribution Network, Material |
-| Composite | `#E0E0E0` | Grouping, Location |
-
-### Extract shapes from existing diagrams
-
-```bash
-npx architecture-blocks extract my-diagram.drawio --output shapes/
+```
+YAML shape files (shapes/*.yaml)
+        |
+        v
+  Build (npm run build)
+        |
+        v
+Library XML (libraries/*.xml)  -->  draw.io imports this
+        |
+        v
+  Shapes on diagrams have data-block-id + data-library-version
+        |
+        v
+  CLI matches shapes by data-block-id, diffs styles, upgrades
 ```
 
-Drop ArchiMate shapes on a draw.io canvas, save, run extract — generates YAML definitions automatically. No hand-writing YAML.
+Every shape in the library carries a `data-block-id` in its style string. When you drag a shape onto your canvas and save, that ID persists in the `.drawio` XML. The CLI uses this ID to:
+- **Match** diagram shapes to library definitions
+- **Diff** current styles against the YAML source of truth
+- **Upgrade** only visual properties (colors, stroke, font)
+- **Never touch** positions, connections, labels, or grouping
 
-### Rollback an upgrade
+## Shape Properties
 
-```bash
-npx architecture-blocks rollback path/to/diagram.drawio
+Shapes can define custom properties that appear in draw.io's Edit Data dialog:
+
+```yaml
+# shapes/application/application-component.yaml
+properties:
+  - key: owner
+    label: Owner
+    type: string
+    default: ""
+  - key: status
+    label: Status
+    type: enum
+    default: active
+    options: [active, deprecated, planned, retiring]
+  - key: criticality
+    label: Criticality
+    type: enum
+    default: medium
+    options: [low, medium, high, critical]
 ```
 
-### View version history
+Properties give shapes **context** — they're not just visual elements, they carry metadata about ownership, lifecycle, criticality, automation level, etc.
 
-```bash
-npx architecture-blocks versions
-npx architecture-blocks diff-versions 0.1.0 0.2.0
-```
+## ArchiMate 3.2 Coverage
 
-## Programmatic API
+60 of 60 element types covered (100%):
 
-```typescript
-import { SHAPES, SHAPES_BY_ID, generateLibraryXml, VERSION, LIBRARY_PATH } from "@ea-toolkit/architecture-blocks";
-```
+| Layer | Shapes | Fill |
+|-------|--------|------|
+| Application | 9 | `#99ffff` |
+| Business | 13 | `#ffff99` |
+| Technology | 13 | `#99ff99` |
+| Strategy | 4 | `#F5DEAA` |
+| Motivation | 10 | `#CCCCFF` |
+| Implementation | 5 | `#FFE0E0` |
+| Physical | 4 | `#99ff99` |
+| Composite | 2 | `#E0E0E0` |
 
-## CI integration
+[Full coverage report](docs/archimate-coverage.md)
 
-Add to your CI pipeline to catch stale diagrams:
+## CI Integration
 
 ```yaml
 - name: Check diagram styles
   run: npx architecture-blocks check ./diagrams
 ```
 
-The check command exits with code 1 if any shapes need upgrading, failing the pipeline.
+Exit code 1 fails the pipeline when shapes are stale. See the [Enterprise Guide](docs/enterprise-guide.md) for advanced patterns (scheduled upgrades, PR comments).
 
-See [Enterprise Adoption Guide](docs/enterprise-guide.md) for advanced CI patterns (scheduled upgrades, PR comments).
+## Custom Extensions
 
-## Custom extensions
-
-Add org-specific shapes alongside the standard library:
+Add org-specific shapes without forking:
 
 ```json
 // .architecture-blocksrc.json
@@ -133,7 +167,16 @@ Add org-specific shapes alongside the standard library:
 
 Extension shapes follow the same YAML schema and are included in check/upgrade commands.
 
-## Exit codes
+## Programmatic API
+
+```typescript
+import {
+  SHAPES, SHAPES_BY_ID, generateLibraryXml,
+  VERSION, LIBRARY_PATH
+} from "@ea-toolkit/architecture-blocks";
+```
+
+## Exit Codes
 
 | Code | Meaning |
 |------|---------|
@@ -143,11 +186,12 @@ Extension shapes follow the same YAML schema and are included in check/upgrade c
 
 ## Documentation
 
-- [Enterprise Adoption Guide](docs/enterprise-guide.md) — rollout, CI patterns, governance
-- [ArchiMate 3.2 Coverage](docs/archimate-coverage.md) — 60/60 element types covered
-- [Versioning Strategy](docs/VERSIONING.md) — semver rules, deprecation process
-- [Breaking Change Policy](docs/BREAKING_CHANGES.md) — how changes are communicated
-- [Security Policy](SECURITY.md) — vulnerability reporting, supply chain security
+- [Full Documentation (GitHub Pages)](https://ea-toolkit.github.io/architecture-blocks/)
+- [Enterprise Adoption Guide](docs/enterprise-guide.md)
+- [ArchiMate 3.2 Coverage](docs/archimate-coverage.md)
+- [Versioning Strategy](docs/VERSIONING.md)
+- [Breaking Change Policy](docs/BREAKING_CHANGES.md)
+- [Security Policy](SECURITY.md)
 
 ## License
 

--- a/docs/enterprise-guide.md
+++ b/docs/enterprise-guide.md
@@ -99,6 +99,29 @@ Use the GitHub issue templates:
 3. CI validates YAML, runs tests, checks round-trip
 4. Merge → release → consumers upgrade
 
+## Shape Properties (Context Metadata)
+
+Shapes aren't just visual — they carry context. Properties defined in YAML appear in draw.io's Edit > Edit Data dialog when architects use the shapes:
+
+```yaml
+properties:
+  - key: owner
+    label: Owner
+    type: string
+  - key: status
+    label: Status
+    type: enum
+    options: [active, deprecated, planned, retiring]
+  - key: criticality
+    label: Criticality
+    type: enum
+    options: [low, medium, high, critical]
+```
+
+This means when someone drags an "Application Component" onto their diagram, they immediately see fields for Owner, Status, and Criticality. These properties are stored in the diagram XML and survive upgrades — the upgrade command only updates visual styles, never property values.
+
+Enterprise teams should define properties that match their architecture governance model — ownership, lifecycle stage, compliance classification, data sensitivity, etc.
+
 ## Extension Shapes
 
 Teams can add custom shapes without forking:

--- a/docs/pages/_config.yml
+++ b/docs/pages/_config.yml
@@ -1,0 +1,5 @@
+title: Architecture Blocks
+description: Versioned draw.io shape library for ArchiMate architecture blocks
+remote_theme: pages-themes/minimal@v0.2.0
+plugins:
+  - jekyll-remote-theme

--- a/docs/pages/concepts/how-it-works.md
+++ b/docs/pages/concepts/how-it-works.md
@@ -1,0 +1,131 @@
+---
+layout: default
+title: How It Works
+---
+
+# How It Works
+
+The complete data flow from YAML definition to upgraded diagram.
+
+## The big picture
+
+```
+LIBRARY TEAM                              CONSUMING TEAM
+────────────                              ──────────────
+
+draw.io canvas                            npm install
+     │                                         │
+     ▼                                         ▼
+extract command                           draw.io: import library XML
+     │                                         │
+     ▼                                         ▼
+shapes/*.yaml (source of truth)           drag shapes → create diagrams
+     │                                         │
+     ▼                                         ▼
+validate (JSON schema)                    commit .drawio files
+     │
+     ▼                                    ... time passes ...
+build → libraries/*.xml                   ... library v0.2.0 released ...
+     │
+     ▼                                         │
+GitHub Release                                 ▼
+     │                                    npm update / dependabot PR
+     ▼                                         │
+npm publish + GitHub Packages                  ▼
+                                          CI: npx architecture-blocks check
+                                               │ (exit code 1 = stale)
+                                               ▼
+                                          npx architecture-blocks upgrade
+                                               │
+                                               ▼
+                                          commit updated .drawio files ✓
+```
+
+## Step by step: what happens during an upgrade
+
+### 1. Scan
+
+The CLI recursively finds all `.drawio` files in the given path. Skips `node_modules/`, `dist/`, and dotfiles. Respects `.gitignore` patterns. Supports monorepos with workspace detection.
+
+### 2. Parse
+
+Each `.drawio` file is XML. The parser handles:
+- **Uncompressed XML** — reads directly
+- **Compressed content** — base64-decodes, inflates, then parses
+- **Multi-page diagrams** — processes each page independently
+
+The parser extracts every `<mxCell>` and `<object>` element with its style string, attributes, and geometry.
+
+### 3. Match
+
+For each shape (vertex), the matcher looks for `data-block-id` in:
+1. The cell's custom attributes (if wrapped in `<object>`)
+2. The style string (e.g., `data-block-id=application-component`)
+
+If found, it looks up the corresponding YAML definition. If the `data-library-version` doesn't match the current library version, the shape is flagged as needing upgrade.
+
+Shapes without `data-block-id` are silently skipped — they're not managed by this library.
+
+### 4. Diff
+
+The differ compares the shape's current style against the YAML definition. It only checks **visual properties**:
+
+| Checked (visual) | NOT checked (layout) |
+|-------------------|---------------------|
+| fillColor | x, y position |
+| strokeColor | width, height |
+| strokeWidth | connections (edges) |
+| fontColor | labels / text content |
+| fontSize | parent / grouping |
+| fontStyle | rotation |
+| fontFamily | |
+
+### 5. Upgrade
+
+The upgrader applies style changes by doing a **string replacement** on the raw XML. This is intentional — it guarantees that positions, connections, labels, and every other attribute survives untouched. The XML is not reparsed and re-serialized, which would risk reordering attributes or reformatting whitespace.
+
+It also updates `data-library-version` to the new version.
+
+### 6. Validate and write
+
+Before writing:
+1. A `.drawio.bak` backup is created
+2. The modified XML is validated (syntax check + `<mxfile>` root check)
+3. If validation fails → abort, restore from backup
+4. If validation passes → write the file, remove the backup
+
+## Why string replacement instead of DOM manipulation?
+
+draw.io files are XML, but their structure is loose and varies between draw.io versions, platforms, and user actions. Re-serializing after DOM parsing can:
+- Reorder XML attributes
+- Change whitespace and formatting
+- Alter encoding of special characters
+- Trigger false positives in git diffs
+
+String replacement on the style attribute is surgical — it changes exactly what needs to change and nothing else. The tradeoff is that it requires the style string to be an exact match, which is why we use `data-block-id` as the lookup key rather than guessing based on visual appearance.
+
+## What about custom properties?
+
+Properties (owner, status, criticality, etc.) are stored as XML attributes on `<object>` elements:
+
+```xml
+<object id="2" label="My Component" owner="Team Alpha" status="active" criticality="high">
+  <mxCell style="shape=mxgraph.archimate3.application;..." vertex="1" parent="1">
+    <mxGeometry width="120" height="60" as="geometry"/>
+  </mxCell>
+</object>
+```
+
+The upgrade command **never touches properties**. It only updates the `style` attribute inside `<mxCell>`. So if a user has filled in `owner="Team Alpha"`, that value is preserved across every upgrade.
+
+## The unique identifier
+
+Every managed shape has this in its draw.io style string:
+
+```
+data-block-id=application-component;data-library-version=0.1.0
+```
+
+`data-block-id` is the **join key** between diagrams and the YAML library. It's set when the shape is first placed on a canvas (from the library) and never changes during upgrades.
+
+This is what makes deterministic matching possible — no guessing based on visual appearance, no pattern matching on shape names. A `data-block-id=application-component` shape will always match the `application-component.yaml` definition.

--- a/docs/pages/concepts/shape-identity.md
+++ b/docs/pages/concepts/shape-identity.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: Shape Identity
+---
+
+# Shape Identity
+
+How shapes are identified, versioned, and tracked across diagrams.
+
+## data-block-id
+
+Every shape in the library carries a `data-block-id` in its style string. This is a stable, kebab-case identifier that uniquely identifies the shape type:
+
+```
+data-block-id=application-component
+data-block-id=business-actor
+data-block-id=technology-service
+```
+
+The block ID:
+- Is set when the shape is first placed on a canvas from the library
+- Persists in the `.drawio` XML file when saved
+- Survives copy-paste, export/import, and draw.io version upgrades
+- Is never modified by the upgrade command
+- Is the **join key** between diagrams and YAML definitions
+
+## data-library-version
+
+Each shape also carries the library version that created or last upgraded it:
+
+```
+data-library-version=0.1.0
+```
+
+The CLI uses this to determine if a shape is stale:
+- If `data-library-version` matches the installed library → up to date
+- If it doesn't match → stale, needs upgrade
+
+## Where they live in the XML
+
+### Simple shapes (no custom properties)
+
+```xml
+<mxCell id="2"
+        value="My Component"
+        style="shape=mxgraph.archimate3.application;fillColor=#99ffff;...;data-block-id=application-component;data-library-version=0.1.0"
+        vertex="1" parent="1">
+  <mxGeometry x="100" y="200" width="120" height="60" as="geometry"/>
+</mxCell>
+```
+
+### Shapes with custom properties
+
+```xml
+<object id="2" label="My Component" owner="Team Alpha" status="active">
+  <mxCell style="shape=mxgraph.archimate3.application;fillColor=#99ffff;...;data-block-id=application-component;data-library-version=0.1.0"
+          vertex="1" parent="1">
+    <mxGeometry x="100" y="200" width="120" height="60" as="geometry"/>
+  </mxCell>
+</object>
+```
+
+Note: `data-block-id` and `data-library-version` are in the **style string**, not as separate XML attributes. This ensures they survive draw.io's internal operations.
+
+## How matching works
+
+```
+Diagram shape                     Library definition
+─────────────                     ──────────────────
+style contains                    shapes/application/
+  data-block-id=                    application-component.yaml
+  application-component    ──→       blockId: application-component
+                                     visual:
+style contains                         fillColor: "#A0E8E8"  ← compare
+  fillColor=#99ffff        ──→         (different!)
+
+Result: STALE — needs upgrade
+```
+
+The matcher:
+1. Parses the style string to extract `data-block-id`
+2. Looks up the corresponding YAML definition by `blockId`
+3. Compares visual style properties
+4. Reports whether the shape needs an upgrade
+
+## What if a shape has no data-block-id?
+
+It's silently skipped. This means:
+- Shapes from other libraries → ignored
+- Shapes created manually → ignored
+- Plain draw.io shapes (rectangles, arrows, text) → ignored
+
+Only shapes placed from the architecture-blocks library are managed.
+
+## Renaming a block ID (breaking change)
+
+Renaming a `blockId` is a breaking change because every existing diagram references the old ID. The [deprecation process](../reference/breaking-changes.html) handles this:
+
+1. Old shape marked `deprecated: true`, `replacedBy: new-id`
+2. Stays functional for 2 minor versions
+3. Upgrade command migrates `data-block-id` to the new value
+4. Old shape removed in next major version

--- a/docs/pages/concepts/shape-properties.md
+++ b/docs/pages/concepts/shape-properties.md
@@ -1,0 +1,186 @@
+---
+layout: default
+title: Shape Properties
+---
+
+# Shape Properties
+
+Custom metadata that gives shapes context beyond visual appearance.
+
+## Why properties matter
+
+Without properties, an "Application Component" shape is just a colored box with a label. With properties, it becomes:
+
+| Property | Value |
+|----------|-------|
+| Owner | Platform Team |
+| Status | Active |
+| Criticality | High |
+| Data Classification | Confidential |
+
+Properties turn shapes into **context blocks** — they carry the information that architects need to make decisions, not just draw pictures.
+
+## Defining properties in YAML
+
+Properties are defined in the shape's YAML file:
+
+```yaml
+# shapes/application/application-component.yaml
+blockId: application-component
+name: Application Component
+layer: application
+archimate:
+  stencil: mxgraph.archimate3.application
+  typeAttr: appType
+  typeValue: comp
+visual:
+  fillColor: "#99ffff"
+  strokeColor: "#00cccc"
+  fontColor: "#000000"
+  fontSize: 12
+  fontStyle: 0
+dimensions:
+  width: 120
+  height: 60
+properties:
+  - key: owner
+    label: Owner
+    type: string
+    default: ""
+    description: Team or person responsible for this component
+  - key: status
+    label: Status
+    type: enum
+    default: active
+    options:
+      - active
+      - deprecated
+      - planned
+      - retiring
+    description: Current lifecycle status
+  - key: criticality
+    label: Criticality
+    type: enum
+    default: medium
+    options:
+      - low
+      - medium
+      - high
+      - critical
+    description: Business criticality level
+```
+
+## Property types
+
+| Type | Description | Example |
+|------|------------|---------|
+| `string` | Free text | Owner name, URL, description |
+| `enum` | Dropdown with predefined options | Status, criticality, environment |
+| `boolean` | True/false toggle | isExternalFacing, requiresAuth |
+| `number` | Numeric value | SLA percentage, cost tier |
+
+## How properties appear in draw.io
+
+When someone drags a shape with properties onto their canvas, the properties appear in **Edit > Edit Data** (or right-click > Edit Data):
+
+- Each property shows its **label** as the field name
+- **enum** types appear as dropdown selectors (if draw.io supports it via custom plugins) or as text fields where the user enters one of the options
+- **default** values are pre-filled
+
+The values are stored as XML attributes on the `<object>` element:
+
+```xml
+<object id="2" label="Payment Service"
+        owner="Platform Team"
+        status="active"
+        criticality="high">
+  <mxCell style="..." vertex="1" parent="1">
+    <mxGeometry width="120" height="60" as="geometry"/>
+  </mxCell>
+</object>
+```
+
+## Properties survive upgrades
+
+The upgrade command only modifies the `style` attribute inside `<mxCell>`. Property values on the `<object>` wrapper are never touched. So if a user has set `owner="Platform Team"`, that value persists through every library upgrade.
+
+## Extracting properties from existing diagrams
+
+If you've added properties to shapes in draw.io (via Edit Data), the extract command captures them:
+
+```bash
+npx architecture-blocks extract my-diagram.drawio
+```
+
+The extractor reads custom attributes from `<object>` elements and includes them in the generated YAML as properties.
+
+## Property design guidelines
+
+When designing properties for your organization:
+
+**Do:**
+- Use properties for metadata that matters for governance (owner, status, classification)
+- Keep property keys short and camelCase (`dataClassification`, not `Data Classification Level`)
+- Provide sensible defaults
+- Use `enum` type with `options` when there's a fixed set of valid values
+- Add `description` to help users understand what to fill in
+
+**Don't:**
+- Don't use properties for visual styling (that's what the `visual` section is for)
+- Don't create too many properties — 3-5 per shape is usually enough
+- Don't use properties for data that changes frequently (properties are set once, rarely updated)
+- Don't put sensitive information in properties (diagram files are often committed to git)
+
+## Example properties by shape type
+
+### Application Component
+```yaml
+properties:
+  - key: owner
+    label: Owner
+    type: string
+  - key: status
+    label: Status
+    type: enum
+    options: [active, deprecated, planned, retiring]
+  - key: criticality
+    label: Criticality
+    type: enum
+    options: [low, medium, high, critical]
+  - key: dataClassification
+    label: Data Classification
+    type: enum
+    options: [public, internal, confidential, restricted]
+```
+
+### Business Process
+```yaml
+properties:
+  - key: processOwner
+    label: Process Owner
+    type: string
+  - key: automationLevel
+    label: Automation Level
+    type: enum
+    options: [manual, semi-automated, fully-automated]
+  - key: maturity
+    label: Maturity
+    type: enum
+    options: [initial, defined, managed, optimized]
+```
+
+### Technology Node
+```yaml
+properties:
+  - key: environment
+    label: Environment
+    type: enum
+    options: [dev, staging, production]
+  - key: provider
+    label: Cloud Provider
+    type: enum
+    options: [aws, azure, gcp, on-premise]
+  - key: costCenter
+    label: Cost Center
+    type: string
+```

--- a/docs/pages/concepts/yaml-schema.md
+++ b/docs/pages/concepts/yaml-schema.md
@@ -1,0 +1,126 @@
+---
+layout: default
+title: YAML Schema
+---
+
+# YAML Schema
+
+The shape definition format explained field by field.
+
+## File structure
+
+Each shape is one YAML file at `shapes/<layer>/<block-id>.yaml`:
+
+```
+shapes/
+├── application/
+│   ├── application-component.yaml
+│   ├── application-service.yaml
+│   └── ...
+├── business/
+│   ├── business-actor.yaml
+│   └── ...
+└── ...
+```
+
+## Complete example
+
+```yaml
+blockId: application-component
+name: Application Component
+layer: application
+archimate:
+  stencil: mxgraph.archimate3.application
+  typeAttr: appType
+  typeValue: comp
+visual:
+  fillColor: "#99ffff"
+  strokeColor: "#00cccc"
+  fontColor: "#000000"
+  fontSize: 12
+  fontStyle: 0
+dimensions:
+  width: 120
+  height: 60
+properties:
+  - key: owner
+    label: Owner
+    type: string
+    default: ""
+    description: Team or person responsible
+  - key: status
+    label: Status
+    type: enum
+    default: active
+    options: [active, deprecated, planned, retiring]
+```
+
+## Field reference
+
+### Required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `blockId` | string | Unique kebab-case identifier. Becomes `data-block-id` in draw.io. **Never rename without deprecation.** |
+| `name` | string | Human-readable name shown in draw.io shape palette |
+| `layer` | enum | ArchiMate layer: `application`, `business`, `technology`, `strategy`, `motivation`, `implementation`, `physical`, `composite` |
+| `archimate.stencil` | string | draw.io stencil ID (e.g., `mxgraph.archimate3.application`) |
+| `archimate.typeAttr` | string | ArchiMate type attribute name (e.g., `appType`) |
+| `archimate.typeValue` | string | ArchiMate type value (e.g., `comp`, `serv`, `actor`) |
+| `visual.fillColor` | hex | Background color (`#RRGGBB`) |
+| `visual.strokeColor` | hex | Border color (`#RRGGBB`) |
+| `visual.fontColor` | hex | Text color (`#RRGGBB`) |
+| `visual.fontSize` | integer | Font size (8-48) |
+| `dimensions.width` | integer | Default width in pixels (20-500) |
+| `dimensions.height` | integer | Default height in pixels (20-500) |
+
+### Optional fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `visual.fontStyle` | integer | 0=normal, 1=bold, 2=italic, 3=bold+italic |
+| `properties` | array | Custom properties (see below) |
+| `deprecated` | boolean | Whether this shape is deprecated |
+| `deprecatedSince` | string | Version when deprecated (e.g., "0.3.0") |
+| `replacedBy` | string | blockId of replacement shape |
+
+### Property fields
+
+Each entry in the `properties` array:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `key` | yes | string | Attribute name in XML (camelCase recommended) |
+| `label` | yes | string | Display label in draw.io Edit Data |
+| `type` | no | enum | `string`, `enum`, `boolean`, `number` (default: `string`) |
+| `default` | no | string | Default value |
+| `options` | no | string[] | Valid values for `enum` type |
+| `required` | no | boolean | Whether this property must be filled in |
+| `description` | no | string | Help text |
+
+## Validation
+
+YAML files are validated against `schemas/shape.schema.json` during build:
+
+```bash
+npm run validate
+# All 60 shape YAML files valid.
+```
+
+The validator catches:
+- Missing required fields
+- Invalid `layer` values
+- Malformed hex color codes
+- blockId not matching kebab-case pattern
+- Dimensions outside valid range
+- Unknown fields (strict schema, no extras)
+
+## The JSON Schema
+
+The full schema is at `schemas/shape.schema.json`. It uses JSON Schema draft-07 and can be used with any JSON Schema validator.
+
+To validate a single file manually:
+
+```bash
+npx ajv validate -s schemas/shape.schema.json -d shapes/application/application-component.yaml
+```

--- a/docs/pages/guides/enterprise.md
+++ b/docs/pages/guides/enterprise.md
@@ -1,0 +1,195 @@
+---
+layout: default
+title: Enterprise Adoption Guide
+---
+
+# Enterprise Adoption Guide
+
+How to evaluate, pilot, and roll out architecture-blocks across your organization.
+
+## Phased rollout
+
+### Phase 1: Evaluate (1 team, 1 week)
+
+1. Install in a single project: `npm install @ea-toolkit/architecture-blocks`
+2. Import library into draw.io
+3. Create a few diagrams using managed shapes
+4. Run `check` and `upgrade` commands to see how they work
+5. Assess: does the library cover your ArchiMate needs?
+
+### Phase 2: Pilot (2-3 teams, 2 weeks)
+
+1. Add to shared dev dependencies
+2. Add `npx architecture-blocks check` to CI pipelines
+3. Teams create diagrams using the standard library
+4. Gather feedback on missing shapes, property needs, style preferences
+5. Create extension shapes for org-specific notation
+
+### Phase 3: Standardize (org-wide)
+
+1. Add to org-level CI template
+2. Set up shape change governance (CODEOWNERS)
+3. Publish extension shape packs for different business units
+4. Document in architecture team wiki
+5. Set up scheduled upgrade workflow
+
+## CI integration patterns
+
+### Pattern 1: PR check (blocking)
+
+```yaml
+- name: Check diagram styles
+  run: npx architecture-blocks check
+```
+
+Exit code 1 fails the pipeline if shapes are outdated. Best for teams that want strict consistency.
+
+### Pattern 2: Scheduled auto-upgrade
+
+```yaml
+name: Upgrade Diagrams
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday mornings
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx architecture-blocks upgrade
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          title: 'chore: upgrade architecture block styles'
+          branch: chore/upgrade-diagram-styles
+```
+
+Automatic, low-friction. A PR appears every Monday if shapes are stale.
+
+### Pattern 3: PR comment (non-blocking)
+
+```yaml
+- name: Check diagrams
+  id: check
+  run: npx architecture-blocks check 2>&1 || true
+  continue-on-error: true
+- name: Comment on PR
+  if: steps.check.outcome == 'failure'
+  uses: actions/github-script@v7
+  with:
+    script: |
+      github.rest.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: 'Some diagram shapes are outdated. Run `npx architecture-blocks upgrade` to fix.'
+      })
+```
+
+Informational. Doesn't block the PR, just nudges the developer.
+
+## Shape properties for governance
+
+Properties are where architecture governance meets daily work. Define properties that match your governance model:
+
+```yaml
+properties:
+  - key: owner
+    label: Owner
+    type: string
+    description: Team responsible for this component
+  - key: status
+    label: Status
+    type: enum
+    options: [active, deprecated, planned, retiring]
+  - key: dataClassification
+    label: Data Classification
+    type: enum
+    options: [public, internal, confidential, restricted]
+```
+
+When architects use these shapes, they're prompted to fill in governance metadata as they draw — not as an afterthought.
+
+## Extension shapes
+
+Teams can add org-specific shapes without forking:
+
+1. Create a `custom-shapes/` directory with the same layer structure
+2. Add `.architecture-blocksrc.json`:
+
+```json
+{
+  "extensions": ["./custom-shapes"]
+}
+```
+
+3. Extension shapes follow the same YAML schema
+4. Included in check/upgrade commands automatically
+
+## Governance workflow
+
+### Who owns the shape library?
+The architecture team or platform team. Shape changes go through PR review.
+
+### How are changes proposed?
+GitHub issue templates:
+- **Shape Request** — new shapes
+- **Style Change** — color/font updates
+- **Bug Report** — rendering issues
+
+### How are changes approved?
+1. PR with YAML changes in `shapes/`
+2. CODEOWNERS review (architecture team)
+3. CI validates YAML, runs 415 tests, checks round-trip integrity
+4. Merge → GitHub Release → npm publish (automated)
+
+## Version management
+
+| Release type | Safety | Action |
+|-------------|--------|--------|
+| Patch (0.1.x) | Safe to auto-upgrade | Style-only changes |
+| Minor (0.x.0) | Review migration guide | May add new shapes |
+| Major (x.0.0) | Read breaking changes | May remove shapes |
+
+```bash
+# Before upgrading
+npx architecture-blocks diff-versions 0.1.0 0.2.0
+npx architecture-blocks upgrade --dry-run
+
+# Upgrade
+npx architecture-blocks upgrade
+
+# Roll back one file if needed
+npx architecture-blocks rollback path/to/diagram.drawio
+```
+
+## Monorepo support
+
+The scanner detects npm/yarn/pnpm workspaces and scans all packages:
+
+```bash
+npx architecture-blocks check    # scans all workspace packages
+```
+
+## FAQ
+
+**Does this work offline?**
+Yes. No network requests at runtime. Everything is local.
+
+**Can I use this with draw.io online?**
+Yes. Import the library XML through File > Open Library from > Device.
+
+**What about diagrams created before adoption?**
+Existing shapes without `data-block-id` are silently skipped. Only library shapes are managed.
+
+**Can teams use different versions?**
+Yes. Each project pins its own version in package.json.
+
+**Is there telemetry?**
+No. Zero analytics, zero tracking, fully offline.
+
+**What about supply chain security?**
+npm provenance attestation on every release. Verify with `npm audit signatures`. 3 runtime dependencies, all audited.

--- a/docs/pages/guides/extensions.md
+++ b/docs/pages/guides/extensions.md
@@ -1,0 +1,135 @@
+---
+layout: default
+title: Custom Extensions
+---
+
+# Custom Extensions
+
+Add org-specific shapes without forking the library.
+
+## Why extensions?
+
+Your organization likely has notation beyond standard ArchiMate — internal system types, custom classification shapes, org-specific diagram elements. Extensions let you:
+
+- Define custom shapes that follow the same YAML schema
+- Include them in `check` and `upgrade` commands
+- Generate library XML that combines standard + custom shapes
+- Keep custom shapes in your own repo, version-controlled
+
+## Setting up extensions
+
+### 1. Create extension shapes directory
+
+```
+your-project/
+├── custom-shapes/
+│   ├── internal/
+│   │   ├── microservice.yaml
+│   │   └── data-lake.yaml
+│   └── compliance/
+│       ├── gdpr-boundary.yaml
+│       └── pci-zone.yaml
+├── .architecture-blocksrc.json
+└── package.json
+```
+
+### 2. Add config file
+
+```json
+// .architecture-blocksrc.json
+{
+  "extensions": ["./custom-shapes"]
+}
+```
+
+Or in `package.json`:
+
+```json
+{
+  "architecture-blocks": {
+    "extensions": ["./custom-shapes"]
+  }
+}
+```
+
+### 3. Write extension shape YAML
+
+Follow the exact same schema as standard shapes:
+
+```yaml
+# custom-shapes/internal/microservice.yaml
+blockId: custom-microservice
+name: Microservice
+layer: application
+archimate:
+  stencil: mxgraph.archimate3.application
+  typeAttr: appType
+  typeValue: comp
+visual:
+  fillColor: "#B8E6FF"
+  strokeColor: "#4A90D9"
+  fontColor: "#000000"
+  fontSize: 12
+  fontStyle: 0
+dimensions:
+  width: 120
+  height: 60
+properties:
+  - key: runtime
+    label: Runtime
+    type: enum
+    default: node
+    options: [node, java, python, go, dotnet]
+  - key: team
+    label: Owning Team
+    type: string
+```
+
+### 4. Validate
+
+```bash
+npx architecture-blocks check
+# Now includes both standard and extension shapes
+```
+
+## Naming convention
+
+Prefix extension blockIds to avoid collisions with the standard library:
+
+```yaml
+blockId: custom-microservice      # good
+blockId: org-data-lake            # good
+blockId: application-component    # bad — collides with standard library
+```
+
+## Extracting extension shapes
+
+Use the extract command with a custom output directory:
+
+```bash
+npx architecture-blocks extract our-reference.drawio --output custom-shapes/
+```
+
+## Distributing extensions
+
+### Option 1: In-repo (simplest)
+Keep `custom-shapes/` in your project repo. Everyone who clones the repo gets them.
+
+### Option 2: Separate npm package
+Publish your extensions as a package:
+
+```json
+// .architecture-blocksrc.json
+{
+  "extensions": ["./node_modules/@your-org/architecture-extensions/shapes"]
+}
+```
+
+### Option 3: Shared directory
+Point to a shared network or mounted drive:
+
+```json
+{
+  "extensions": ["/shared/architecture/custom-shapes"]
+}
+```

--- a/docs/pages/guides/installation.md
+++ b/docs/pages/guides/installation.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: Installation
+---
+
+# Installation
+
+## Requirements
+
+- Node.js 18 or later
+- npm (comes with Node.js)
+- draw.io desktop or online (app.diagrams.net)
+
+## Install the package
+
+```bash
+npm install @ea-toolkit/architecture-blocks
+```
+
+Or as a dev dependency (if you only need it for CI checks):
+
+```bash
+npm install --save-dev @ea-toolkit/architecture-blocks
+```
+
+## Import the shape library into draw.io
+
+### Full library (all 60 shapes)
+
+1. Open draw.io
+2. File > Open Library from > Device
+3. Navigate to your project's `node_modules/@ea-toolkit/architecture-blocks/libraries/`
+4. Select `architecture-blocks.xml`
+
+The shapes appear in the sidebar under "Architecture Blocks".
+
+### Per-layer libraries
+
+If you only work with specific ArchiMate layers, import just the layers you need:
+
+| File | Shapes |
+|------|--------|
+| `architecture-blocks-application.xml` | 9 application shapes |
+| `architecture-blocks-business.xml` | 13 business shapes |
+| `architecture-blocks-technology.xml` | 13 technology shapes |
+| `architecture-blocks-strategy.xml` | 4 strategy shapes |
+| `architecture-blocks-motivation.xml` | 10 motivation shapes |
+| `architecture-blocks-implementation.xml` | 5 implementation shapes |
+| `architecture-blocks-physical.xml` | 4 physical shapes |
+| `architecture-blocks-composite.xml` | 2 composite shapes |
+
+### draw.io plugin (auto-import)
+
+For teams who want the library loaded automatically:
+
+1. Copy `plugin/architecture-blocks-plugin.js` to a shared location
+2. In draw.io: Extras > Plugins > Add > select the plugin file
+3. Restart draw.io
+
+The plugin auto-loads the library on startup.
+
+## Verify installation
+
+```bash
+npx architecture-blocks version
+# architecture-blocks v0.1.0
+#   Shapes: 60
+#   Library: /path/to/libraries
+```
+
+## What's in the package?
+
+```
+@ea-toolkit/architecture-blocks/
+├── dist/           # CLI + library JavaScript
+├── libraries/      # Generated draw.io XML files (importable)
+├── shapes/         # YAML source definitions
+└── schemas/        # JSON Schema for shape YAML
+```
+
+[Next: Quick Start >](quick-start.html)

--- a/docs/pages/guides/library-authors.md
+++ b/docs/pages/guides/library-authors.md
@@ -1,0 +1,177 @@
+---
+layout: default
+title: For Library Authors
+---
+
+# For Library Authors
+
+How to add new shapes, update styles, and manage the shape library.
+
+## Adding a new shape
+
+### Option A: Extract from draw.io (recommended)
+
+The fastest way. No hand-writing YAML or XML.
+
+1. **Open draw.io** and drag the ArchiMate shape you want onto a blank canvas
+2. Style it how you want (colors, font, size)
+3. Add custom properties via Edit > Edit Data (owner, status, etc.)
+4. Save as `reference.drawio`
+5. Run the extract command:
+
+```bash
+npx architecture-blocks extract reference.drawio --output shapes/
+#   extracted application-component → application/application-component.yaml
+```
+
+6. Review the generated YAML file
+7. Commit, create PR, get review, merge
+
+**Bulk extraction**: drop as many shapes as you want on the canvas. The extract command processes all of them in one go.
+
+### Option B: Write YAML manually
+
+Create a file like `shapes/application/my-new-shape.yaml`:
+
+```yaml
+blockId: my-new-shape
+name: My New Shape
+layer: application
+archimate:
+  stencil: mxgraph.archimate3.application
+  typeAttr: appType
+  typeValue: comp
+visual:
+  fillColor: "#99ffff"
+  strokeColor: "#00cccc"
+  fontColor: "#000000"
+  fontSize: 12
+  fontStyle: 0
+dimensions:
+  width: 120
+  height: 60
+properties:
+  - key: owner
+    label: Owner
+    type: string
+    default: ""
+```
+
+Run `npm run validate` to check it against the schema.
+
+## Updating a reference file
+
+When you use the same `reference.drawio` over time:
+
+| Action | What happens |
+|--------|-------------|
+| **Add new shapes** to canvas, re-run extract | New shapes extracted, existing ones skipped |
+| **Update existing shapes** on canvas, re-run extract | Skipped by default. Use `--force` to overwrite |
+| **Remove shapes** from canvas, re-run extract | YAML files stay (not auto-deleted for safety). Remove manually if needed |
+
+```bash
+# First time: extracts everything
+npx architecture-blocks extract reference.drawio
+
+# Later: added 3 new shapes to reference.drawio
+npx architecture-blocks extract reference.drawio
+#   skip application-component (exists, use --force to overwrite)
+#   extracted new-shape-1 → ...
+#   extracted new-shape-2 → ...
+#   extracted new-shape-3 → ...
+
+# Force overwrite all (after updating styles):
+npx architecture-blocks extract reference.drawio --force
+```
+
+## Updating visual styles
+
+To change colors, fonts, or dimensions:
+
+1. Edit the YAML file(s) directly — e.g., change `fillColor` from `#99ffff` to `#A0E8E8`
+2. Or update shapes in `reference.drawio` and re-extract with `--force`
+3. Run the build to regenerate library XML:
+
+```bash
+npm run validate   # Check YAML is valid
+npm run build      # Regenerate libraries/*.xml
+npm test           # Verify round-trip integrity
+```
+
+## Adding shape properties
+
+Properties give shapes context. Define them in the YAML:
+
+```yaml
+properties:
+  - key: owner
+    label: Owner
+    type: string
+    default: ""
+    description: Team or person responsible
+  - key: status
+    label: Status
+    type: enum
+    default: active
+    options:
+      - active
+      - deprecated
+      - planned
+      - retiring
+    description: Current lifecycle status
+```
+
+Property types:
+- **string** — free text
+- **enum** — dropdown with predefined options
+- **boolean** — true/false
+- **number** — numeric value
+
+Properties appear in draw.io's Edit > Edit Data dialog when someone uses the shape.
+
+## Deprecating a shape
+
+Don't delete shapes — deprecate them first:
+
+```yaml
+blockId: old-shape
+deprecated: true
+deprecatedSince: "0.3.0"
+replacedBy: new-shape
+```
+
+The CLI will warn consumers during check/upgrade. After 2 minor versions, the shape can be removed in a major release. See [Breaking Change Policy](../reference/breaking-changes.html).
+
+## The build pipeline
+
+```
+shapes/*.yaml  →  npm run validate  →  npm run build  →  libraries/*.xml
+                  (schema check)       (tsup + generate)  (draw.io libraries)
+```
+
+### What `npm run build` does:
+1. **tsup** bundles TypeScript → `dist/` (CLI + library)
+2. **generate-library.ts** reads all YAML → generates `libraries/*.xml`
+
+### What `npm run validate` does:
+- Reads every YAML file in `shapes/`
+- Validates against `schemas/shape.schema.json`
+- Fails with clear error if any file is invalid
+
+### What `npm test` does (415 tests):
+- **Parser tests** — XML parsing, multi-page, compressed content
+- **Matcher tests** — shape matching by data-block-id
+- **Differ tests** — style comparison
+- **Upgrader tests** — style updates, position preservation, backup
+- **CLI tests** — all commands, exit codes
+- **Round-trip tests** — generate XML → parse back → verify all 60 shapes
+- **Coverage tests** — ArchiMate 3.2 completeness (60/60)
+
+## Releasing
+
+1. Commit your changes, create PR, get review
+2. Merge to master → CI runs automatically
+3. Create a GitHub Release with a semver tag (e.g., `v0.2.0`)
+4. GitHub Actions publishes to npm (with provenance) and GitHub Packages
+
+See [Versioning Strategy](../reference/versioning.html) for when to bump major/minor/patch.

--- a/docs/pages/guides/quick-start.md
+++ b/docs/pages/guides/quick-start.md
@@ -1,0 +1,90 @@
+---
+layout: default
+title: Quick Start
+---
+
+# Quick Start
+
+Get from zero to managed architecture diagrams in 5 minutes.
+
+## Step 1: Install
+
+```bash
+npm install @ea-toolkit/architecture-blocks
+```
+
+## Step 2: Import into draw.io
+
+1. Open draw.io
+2. File > Open Library from > Device
+3. Select `node_modules/@ea-toolkit/architecture-blocks/libraries/architecture-blocks.xml`
+
+You'll see 60 ArchiMate shapes in the sidebar, organized by layer.
+
+## Step 3: Create a diagram
+
+Drag shapes from the library onto your canvas. Each shape automatically carries:
+- **data-block-id** — e.g., `application-component` (the upgrade key)
+- **data-library-version** — e.g., `0.1.0` (tracks which version created it)
+- **Custom properties** — accessible via Edit > Edit Data (owner, status, criticality, etc.)
+
+Draw your connections, add labels, position things however you like. Save as `my-architecture.drawio`.
+
+## Step 4: Check your diagram
+
+```bash
+npx architecture-blocks check .
+# 5 blocks found, 0 stale across 1 of 1 files
+```
+
+All shapes are up to date. Exit code 0 means everything matches the library.
+
+## Step 5: Simulate a library update
+
+Imagine the library team updates the Application layer colors in the next release. After updating the package:
+
+```bash
+npx architecture-blocks check .
+# 5 blocks found, 3 stale across 1 of 1 files
+# Exit code: 1
+```
+
+Three shapes have outdated styles. Fix them:
+
+```bash
+npx architecture-blocks upgrade .
+# Upgraded 3 shapes in my-architecture.drawio
+```
+
+Open the file in draw.io — positions, connections, and labels are exactly where you left them. Only the visual styles (colors, font) changed to match the new library.
+
+## Step 6: Add to CI
+
+```yaml
+# .github/workflows/check-diagrams.yml
+- name: Check diagram styles
+  run: npx architecture-blocks check
+```
+
+Now PRs that introduce stale shapes will fail CI.
+
+## What just happened?
+
+```
+You installed a versioned shape library
+  ↓
+Imported it into draw.io (shapes carry data-block-id)
+  ↓
+Created diagrams using managed shapes
+  ↓
+CLI can match, diff, and upgrade shapes across all .drawio files
+  ↓
+CI catches drift before it reaches master
+```
+
+## Next steps
+
+- [How It Works](../concepts/how-it-works.html) — understand the full data flow
+- [Shape Properties](../concepts/shape-properties.html) — add context metadata to shapes
+- [For Library Authors](library-authors.html) — add your own shapes
+- [Enterprise Guide](enterprise.html) — roll out across your organization

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -1,0 +1,73 @@
+---
+layout: default
+title: Home
+---
+
+# Architecture Blocks
+
+Versioned draw.io shape library for ArchiMate architecture diagrams — with a CLI to extract, upgrade, check, and manage shapes across all your `.drawio` files.
+
+**60 shapes** covering all 8 ArchiMate 3.2 layers. **YAML-driven** definitions with custom properties. **CI-ready** with exit codes for pipeline integration.
+
+---
+
+## What problem does this solve?
+
+Architecture teams create diagrams in draw.io using ArchiMate shapes. Over time, problems emerge:
+
+- **Style drift** — different people use different colors, fonts, and sizes for the same shape type
+- **No version control** — when the team agrees on a new color scheme, someone has to manually update every diagram
+- **No governance** — anyone can change a shape's appearance, and there's no review process
+- **No context** — shapes are just visual boxes with no metadata (who owns this? what's the status?)
+- **Painful onboarding** — new architects have to find the right shapes, learn the conventions, and hope they match everyone else
+
+Architecture Blocks solves all of these by making shapes **versioned**, **YAML-defined**, **automatically upgradeable**, and **enriched with context properties**.
+
+---
+
+## How it works in 60 seconds
+
+```
+1. Install:          npm install @ea-toolkit/architecture-blocks
+2. Import into draw.io: File > Open Library > architecture-blocks.xml
+3. Draw:             Drag shapes onto your canvas (they carry version + metadata)
+4. Check:            npx architecture-blocks check    (CI: exit 1 if stale)
+5. Upgrade:          npx architecture-blocks upgrade   (updates styles, preserves layout)
+```
+
+---
+
+## Documentation
+
+### Getting Started
+- [Installation](guides/installation.html) — Install the package and import into draw.io
+- [Quick Start](guides/quick-start.html) — Create your first managed diagram in 5 minutes
+- [For Library Authors](guides/library-authors.html) — How to add, update, and manage shapes
+
+### Core Concepts
+- [How It Works](concepts/how-it-works.html) — The data flow from YAML to draw.io and back
+- [Shape Identity](concepts/shape-identity.html) — data-block-id, versioning, and the upgrade mechanism
+- [Shape Properties](concepts/shape-properties.html) — Custom metadata that gives shapes context
+- [YAML Schema](concepts/yaml-schema.html) — The shape definition format explained
+
+### CLI Reference
+- [All Commands](reference/cli.html) — Complete CLI reference with examples
+- [Exit Codes](reference/exit-codes.html) — What each exit code means
+
+### Enterprise
+- [Enterprise Adoption Guide](guides/enterprise.html) — Rollout strategy, CI patterns, governance
+- [Custom Extensions](guides/extensions.html) — Add org-specific shapes without forking
+- [Versioning & Upgrades](reference/versioning.html) — Semver rules, migration, rollback
+
+### Reference
+- [ArchiMate 3.2 Coverage](reference/archimate-coverage.html) — 60/60 element types covered
+- [Breaking Change Policy](reference/breaking-changes.html) — How changes are communicated
+- [Security](reference/security.html) — Supply chain, provenance, vulnerability reporting
+
+---
+
+## Quick links
+
+- [GitHub Repository](https://github.com/ea-toolkit/architecture-blocks)
+- [npm Package](https://www.npmjs.com/package/@ea-toolkit/architecture-blocks)
+- [Issue Tracker](https://github.com/ea-toolkit/architecture-blocks/issues)

--- a/docs/pages/reference/archimate-coverage.md
+++ b/docs/pages/reference/archimate-coverage.md
@@ -1,0 +1,116 @@
+---
+layout: default
+title: ArchiMate 3.2 Coverage
+---
+
+# ArchiMate 3.2 Coverage
+
+**60 of 60 element types covered (100%)**
+
+## Application Layer (9 shapes)
+
+| Element | blockId |
+|---------|---------|
+| Application Component | `application-component` |
+| Application Interface | `application-interface` |
+| Application Function | `application-function` |
+| Application Interaction | `application-interaction` |
+| Application Process | `application-process` |
+| Application Event | `application-event` |
+| Application Service | `application-service` |
+| Application Collaboration | `application-collaboration` |
+| Data Object | `data-object` |
+
+## Business Layer (13 shapes)
+
+| Element | blockId |
+|---------|---------|
+| Business Actor | `business-actor` |
+| Business Role | `business-role` |
+| Business Collaboration | `business-collaboration` |
+| Business Interface | `business-interface` |
+| Business Process | `business-process` |
+| Business Function | `business-function` |
+| Business Interaction | `business-interaction` |
+| Business Event | `business-event` |
+| Business Service | `business-service` |
+| Business Object | `business-object` |
+| Contract | `contract` |
+| Representation | `representation` |
+| Product | `product` |
+
+## Technology Layer (13 shapes)
+
+| Element | blockId |
+|---------|---------|
+| Node | `node` |
+| Device | `device` |
+| System Software | `system-software` |
+| Technology Interface | `technology-interface` |
+| Technology Process | `technology-process` |
+| Technology Function | `technology-function` |
+| Technology Interaction | `technology-interaction` |
+| Technology Event | `technology-event` |
+| Technology Service | `technology-service` |
+| Technology Collaboration | `technology-collaboration` |
+| Artifact | `artifact` |
+| Communication Network | `communication-network` |
+| Path | `path` |
+
+## Strategy Layer (4 shapes)
+
+| Element | blockId |
+|---------|---------|
+| Resource | `resource` |
+| Capability | `capability` |
+| Value Stream | `value-stream` |
+| Course of Action | `course-of-action` |
+
+## Motivation Layer (10 shapes)
+
+| Element | blockId |
+|---------|---------|
+| Stakeholder | `stakeholder` |
+| Driver | `driver` |
+| Assessment | `assessment` |
+| Goal | `goal` |
+| Outcome | `outcome` |
+| Principle | `principle` |
+| Requirement | `requirement` |
+| Constraint | `constraint` |
+| Meaning | `meaning` |
+| Value | `value` |
+
+## Implementation & Migration Layer (5 shapes)
+
+| Element | blockId |
+|---------|---------|
+| Work Package | `work-package` |
+| Deliverable | `deliverable` |
+| Implementation Event | `implementation-event` |
+| Plateau | `plateau` |
+| Gap | `gap` |
+
+## Physical Layer (4 shapes)
+
+| Element | blockId |
+|---------|---------|
+| Equipment | `equipment` |
+| Facility | `facility` |
+| Distribution Network | `distribution-network` |
+| Material | `material` |
+
+## Composite Layer (2 shapes)
+
+| Element | blockId |
+|---------|---------|
+| Grouping | `grouping` |
+| Location | `location` |
+
+## Not Yet Covered
+
+### Relationship Types
+ArchiMate defines relationship types (Composition, Aggregation, Assignment, Serving, Access, Realization, Triggering, Flow, Influence, Specialization, Association). These are edges in draw.io, not shapes. Future release consideration.
+
+### Junction Types
+And Junction, Or Junction. Low priority.

--- a/docs/pages/reference/breaking-changes.md
+++ b/docs/pages/reference/breaking-changes.md
@@ -1,0 +1,52 @@
+---
+layout: default
+title: Breaking Change Policy
+---
+
+# Breaking Change Policy
+
+How shape changes are communicated and how consumers are protected.
+
+## What counts as breaking
+
+| Change | Breaking? | Process |
+|--------|-----------|---------|
+| Shape removed | Yes | Deprecate 2 minor versions, remove in major |
+| blockId renamed | Yes | Alias old ID for 2 minor versions |
+| Layer reassignment | Yes | Same as rename process |
+| Style change (colors, font) | **No** | Handled by `upgrade` command |
+| New shape added | **No** | Additive, no impact |
+| New property added to shape | **No** | Additive, no impact |
+| CLI command removed | Yes | Deprecation warning for 2 minor versions |
+
+## Deprecation lifecycle
+
+```
+v0.3.0  Shape marked deprecated: true
+        CLI check/upgrade show warnings
+        replacedBy field points to new shape
+
+v0.4.0  Shape still works, warnings continue
+
+v0.5.0  Shape still works (last minor before removal)
+        Upgrade command auto-migrates to replacement
+
+v1.0.0  Shape removed
+        Major version = breaking change signal
+```
+
+## YAML deprecation fields
+
+```yaml
+blockId: old-shape-name
+deprecated: true
+deprecatedSince: "0.3.0"
+replacedBy: new-shape-name
+```
+
+## Consumer protection
+
+1. **No surprises.** Breaking changes only in major versions.
+2. **Migration path.** Upgrade command handles transitions automatically.
+3. **Clear communication.** Release notes highlight breaking changes.
+4. **Time to adapt.** 2 minor versions of deprecation before removal.

--- a/docs/pages/reference/cli.md
+++ b/docs/pages/reference/cli.md
@@ -1,0 +1,204 @@
+---
+layout: default
+title: CLI Reference
+---
+
+# CLI Reference
+
+Complete reference for all `architecture-blocks` CLI commands.
+
+## Global
+
+```bash
+npx architecture-blocks --help
+npx architecture-blocks --version    # npm package version
+```
+
+---
+
+## upgrade
+
+Update shape styles in `.drawio` files to match the current library.
+
+```bash
+npx architecture-blocks upgrade [path] [options]
+```
+
+**Arguments:**
+- `path` — directory or file to upgrade (default: current directory)
+
+**Options:**
+- `--dry-run` — show what would change without modifying files
+- `--no-backup` — skip creating `.drawio.bak` backup files
+- `-v, --verbose` — show per-shape detail
+
+**What it does:**
+1. Scans for `.drawio` files recursively
+2. Parses each file, finds shapes with `data-block-id`
+3. Compares current style against library YAML definitions
+4. Updates only visual style properties (fillColor, strokeColor, fontColor, fontSize, etc.)
+5. Updates `data-library-version` to current version
+
+**What it NEVER modifies:**
+- Positions (x, y coordinates)
+- Connections (edges, arrows)
+- Labels (text content)
+- Grouping (parent-child relationships)
+- Custom property values (owner, status, etc.)
+- Dimensions (width, height as placed on canvas)
+
+**Examples:**
+```bash
+# Preview changes
+npx architecture-blocks upgrade ./diagrams --dry-run
+# [dry-run] diagrams/arch.drawio (Page-1)
+#   would update application-component: fillColor, strokeColor
+
+# Upgrade all diagrams
+npx architecture-blocks upgrade ./diagrams
+# 5 blocks found, 3 upgraded across 2 of 4 files
+
+# Upgrade a single file
+npx architecture-blocks upgrade path/to/diagram.drawio
+
+# Upgrade without backups
+npx architecture-blocks upgrade --no-backup
+```
+
+---
+
+## check
+
+Report stale shapes without modifying files. Designed for CI pipelines.
+
+```bash
+npx architecture-blocks check [path] [options]
+```
+
+**Arguments:**
+- `path` — directory or file to check (default: current directory)
+
+**Options:**
+- `-v, --verbose` — show per-shape detail with property diffs
+
+**Exit codes:**
+- `0` — all shapes up to date
+- `1` — stale shapes found
+
+**Examples:**
+```bash
+# Check all diagrams
+npx architecture-blocks check
+# All 5 blocks up to date across 3 files
+
+# Check with detail
+npx architecture-blocks check --verbose
+# stale-file.drawio (Page-1)
+#   stale application-component: fillColor: #80e0e0 → #99ffff
+
+# CI usage
+npx architecture-blocks check || echo "Stale shapes found!"
+```
+
+---
+
+## extract
+
+Extract shape definitions from a `.drawio` file to YAML.
+
+```bash
+npx architecture-blocks extract <file> [options]
+```
+
+**Arguments:**
+- `file` — path to `.drawio` file (required)
+
+**Options:**
+- `-o, --output <dir>` — output directory for YAML files (default: `shapes`)
+- `--force` — overwrite existing YAML files
+
+**What it captures:**
+- ArchiMate stencil type and layer
+- Visual styles (colors, font, dimensions)
+- Custom properties from `<object>` elements (Edit Data attributes)
+
+**Examples:**
+```bash
+# Extract from reference diagram
+npx architecture-blocks extract reference.drawio
+#   extracted application-component → application/application-component.yaml
+#   extracted business-actor → business/business-actor.yaml
+# 2 shapes extracted, 0 skipped.
+
+# Extract to custom directory
+npx architecture-blocks extract reference.drawio --output my-shapes/
+
+# Overwrite existing definitions
+npx architecture-blocks extract reference.drawio --force
+
+# Bulk: drop 20 shapes on one canvas, extract all at once
+npx architecture-blocks extract all-shapes.drawio
+# 20 shapes extracted, 0 skipped.
+```
+
+---
+
+## version
+
+Show installed library version and shape count.
+
+```bash
+npx architecture-blocks version
+# architecture-blocks v0.1.0
+#   Shapes: 60
+#   Library: /path/to/libraries
+```
+
+---
+
+## versions
+
+List all available library versions with their changes.
+
+```bash
+npx architecture-blocks versions
+# 0.1.0 (current) — 2026-03-30
+#   - Initial shape library with all ArchiMate layers
+```
+
+---
+
+## diff-versions
+
+Show changes between two library versions.
+
+```bash
+npx architecture-blocks diff-versions <from> <to>
+```
+
+**Examples:**
+```bash
+npx architecture-blocks diff-versions 0.1.0 0.2.0
+# # Migration Guide: 0.1.0 → 0.2.0
+# ## 0.2.0 (2026-04-15)
+# - Updated Application layer colors
+# - Added 3 new strategy shapes
+```
+
+---
+
+## rollback
+
+Restore a `.drawio` file from its `.bak` backup.
+
+```bash
+npx architecture-blocks rollback <file>
+```
+
+Backup files are created automatically during `upgrade` (unless `--no-backup` is used). The rollback command copies the `.drawio.bak` back to the original file.
+
+**Examples:**
+```bash
+npx architecture-blocks rollback path/to/diagram.drawio
+# Restored path/to/diagram.drawio from backup.
+```

--- a/docs/pages/reference/exit-codes.md
+++ b/docs/pages/reference/exit-codes.md
@@ -1,0 +1,38 @@
+---
+layout: default
+title: Exit Codes
+---
+
+# Exit Codes
+
+Every CLI command returns a meaningful exit code for scripting and CI.
+
+| Code | Meaning | When |
+|------|---------|------|
+| **0** | Success | All shapes up to date, upgrade completed, extraction done |
+| **1** | Stale shapes found | `check` command found shapes that don't match the library |
+| **2** | Error | File not found, parse failure, write failure, validation error |
+
+## CI usage
+
+```bash
+# Fail the pipeline if any shapes are stale
+npx architecture-blocks check
+# Exit 0 = pass, Exit 1 = fail
+
+# Use in conditional logic
+if npx architecture-blocks check; then
+  echo "All diagrams up to date"
+else
+  echo "Run: npx architecture-blocks upgrade"
+  exit 1
+fi
+```
+
+## In GitHub Actions
+
+```yaml
+- name: Check diagram styles
+  run: npx architecture-blocks check
+  # Job fails automatically on exit code 1
+```

--- a/docs/pages/reference/security.md
+++ b/docs/pages/reference/security.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Security
+---
+
+# Security
+
+Supply chain security, provenance, and vulnerability reporting.
+
+## Reporting vulnerabilities
+
+If you discover a security issue:
+
+1. **Do NOT open a public issue**
+2. Email: rajnavakoti@gmail.com with subject "architecture-blocks security"
+3. Include: description, reproduction steps, and impact assessment
+4. Expected response time: 48 hours
+
+## Supply chain security
+
+- Published packages include [npm provenance](https://docs.npmjs.com/generating-provenance-statements) attestation
+- All releases are built by GitHub Actions from the repository
+- Verify provenance: `npm audit signatures`
+- Package lockfile (`package-lock.json`) committed and used in CI (`npm ci`)
+
+## Dependencies
+
+Minimal runtime dependencies — each one justified:
+
+| Package | Purpose | Why not built-in? |
+|---------|---------|-------------------|
+| `commander` | CLI framework | Standard CLI library, battle-tested |
+| `fast-xml-parser` | XML parsing | No native deps, faster than alternatives |
+| `yaml` | YAML shape definitions | Standard YAML parser |
+
+## Automated dependency updates
+
+Dependabot is configured for both npm packages and GitHub Actions, scanning weekly.
+
+## Offline operation
+
+This package makes **zero network requests** at runtime. Everything operates on local files. No analytics, no telemetry, no phone-home.

--- a/docs/pages/reference/versioning.md
+++ b/docs/pages/reference/versioning.md
@@ -1,0 +1,98 @@
+---
+layout: default
+title: Versioning & Upgrades
+---
+
+# Versioning & Upgrades
+
+How versions work, when to upgrade, and how to roll back.
+
+## Semantic versioning
+
+| Bump | When | Examples |
+|------|------|---------|
+| **Major** (1.0.0) | Shape removed, blockId renamed, breaking CLI change | Removing `old-shape`, renaming `app-comp` → `application-component` |
+| **Minor** (0.2.0) | New shapes added, new CLI commands, new YAML fields | Adding strategy shapes, `extract` command |
+| **Patch** (0.1.1) | Style updates, bug fixes, docs | Color change, parser fix |
+
+## Consumer upgrade workflow
+
+### 1. Check what changed
+
+```bash
+npx architecture-blocks diff-versions 0.1.0 0.2.0
+```
+
+### 2. Preview the upgrade
+
+```bash
+npx architecture-blocks upgrade --dry-run
+# [dry-run] Shows what would change without modifying files
+```
+
+### 3. Upgrade
+
+```bash
+npx architecture-blocks upgrade
+# Backups created automatically (.drawio.bak)
+```
+
+### 4. Verify
+
+Open the affected `.drawio` files in draw.io. Visual styles should be updated, everything else untouched.
+
+### 5. Roll back if needed
+
+```bash
+# Per file
+npx architecture-blocks rollback path/to/diagram.drawio
+
+# Or revert to old package version
+npm install @ea-toolkit/architecture-blocks@0.1.0
+```
+
+## Per-diagram upgrade
+
+You don't have to upgrade everything at once:
+
+```bash
+# Upgrade one file
+npx architecture-blocks upgrade path/to/critical-diagram.drawio
+
+# Upgrade one directory
+npx architecture-blocks upgrade src/diagrams/
+
+# Check one file
+npx architecture-blocks check path/to/diagram.drawio
+```
+
+## Version pinning
+
+Each project pins its own version in `package.json`. Teams upgrade on their own schedule.
+
+```json
+{
+  "dependencies": {
+    "@ea-toolkit/architecture-blocks": "0.1.0"
+  }
+}
+```
+
+Use exact versions (no `^` or `~`) if you want full control over when upgrades happen.
+
+## Checking current version across diagrams
+
+Each shape in a diagram carries `data-library-version=0.1.0` in its style. The `check` command reports which shapes are on which version:
+
+```bash
+npx architecture-blocks check --verbose
+# diagram.drawio (Page-1)
+#   stale application-component: fillColor: #80e0e0 → #99ffff
+```
+
+## Automated upgrades in CI
+
+See the [Enterprise Guide](../guides/enterprise.html) for patterns like:
+- Scheduled Monday morning upgrade PRs
+- PR comments when stale shapes are detected
+- Blocking CI when shapes don't match


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md to reflect current architecture (YAML, properties, 7 commands, full project structure)
- Updated README.md with properties, extract workflow, and docs links
- Updated enterprise guide with shape properties section
- **New: 14-page GitHub Pages documentation site** covering:
  - Getting started: installation, quick start, library authors
  - Concepts: how it works, shape identity, properties, YAML schema
  - Reference: CLI commands, exit codes, ArchiMate coverage, versioning, breaking changes, security
  - Enterprise: adoption guide, custom extensions
- GitHub Actions workflow for Pages deployment

## Test plan
- [x] All docs reviewed for accuracy against current codebase
- [x] All internal links verified
- [x] Jekyll config validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)